### PR TITLE
REFACTOR: add dynamic genres and rating to search results

### DIFF
--- a/src/Components/DetailsPage/DetailsTable.js
+++ b/src/Components/DetailsPage/DetailsTable.js
@@ -44,7 +44,7 @@ const DetailsTable = ({ data }) => {
           {streamingServiceDataResult()}
         </div>
       </div>
-      <p>Audience Rating: {Math.round(data.rating)}/10 ⭐️</p>
+      <p>Audience Rating: {Math.round(data.rating * 10) / 10}/10 ⭐️</p>
       <p className="detail-genre-data">Genre: <b>{data.genres.join(", ")}</b></p>
       <p className="detail-summary-data">{data.summary}</p>
       <div className="detail-recommend-data">

--- a/src/Components/RecommendeeCard/RecommendeeCard.js
+++ b/src/Components/RecommendeeCard/RecommendeeCard.js
@@ -76,7 +76,7 @@ const RecommendeeCard = ({ posterUrl, title, releaseYear, rating, genres, date, 
         <Link to={`/show/${tmdbId}`} className='clickable-poster'><img src={posterUrl} className='poster-img' /></Link>
         <div className='recommendee-card-info'>
           <NavLink to={`/show/${tmdbId}`} className='clickable-title'><h1 className='title'>{title} ({releaseYear})</h1></NavLink>
-          <h2 className='audience-rating'>Audience Rating: {rating}/10</h2>
+          <h2 className='audience-rating'>Audience Rating: {Math.round(rating * 10) / 10}/10</h2>
           <h3>{allGenres}</h3>
         </div>
       </div>

--- a/src/Components/SearchPage/SearchPage.js
+++ b/src/Components/SearchPage/SearchPage.js
@@ -26,8 +26,8 @@ const SearchPage = () => {
               posterUrl={show.imageUrl}
               title={show.title}
               releaseYear={show.yearCreated}
-              genres={["placeholder genre", "another placeholder genre"]} //placeholders
-              rating={7} // placeholder rating until BE adds genres/rating to search results
+              genres={show.genres}
+              rating={show.rating}
               key={show.tmdbId}
               tmdbId={show.tmdbId}
             />

--- a/src/Components/WatchListItem/WatchListItem.js
+++ b/src/Components/WatchListItem/WatchListItem.js
@@ -73,7 +73,7 @@ const WatchListItem = ({ posterUrl, title, releaseYear, id, rating, genres, tmdb
                       </button>
                   </div>
                   <div className="rating-and-genres-container">
-                      <h2>Audience Rating: {rating}/10</h2>
+                      <h2>Audience Rating: {Math.round(rating * 10) / 10}/10</h2>
                       <h3 className="watch-list-genres">{allGenres}</h3>
                   </div>
               </div>

--- a/src/GraphQL/Queries.js
+++ b/src/GraphQL/Queries.js
@@ -81,6 +81,8 @@ query shows($query: String!){
       title
       imageUrl
       yearCreated
+      genres
+      rating
   }
 }
 `


### PR DESCRIPTION
- [ ]  Wrote Tests 
- [x] Implemented 
- [ ] Reviewed

## Necessary checkmarks:

- [x] All Tests are Passing in all environments

- [x] The code will run locally

## Type of change

- [ ] New feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Styling
- [ ] Testing
- [ ] This change requires a documentation update


## Description of Change:
This branch adds `genres` and `rating` properties to the `shows()` GraphQL endpoint and adds them to each search result card, removing temporary hard-coded data. 

Logic for rounding ratings to one decimal place has been added to all instances of audience rating being displayed.

## Check the correct boxes

- [x]  This broke nothing
- [ ]  This broke some stuff
- [ ]  This broke everything

## Testing Changes

- [x]  No Tests have been changed
- [ ]  Some Tests have been changed
- [ ]  All of the Tests have been changed(Please describe what in the world happened)


## Checklist:

- [x]  My code has no unused/commented out code
- [x]  My code follows the style guidelines of this project
- [x]  My code does not generate new warnings
- [x]  I have reviewed my code
- [x]  I have commented my code, particularly in hard-to-understand areas (if applicable)