### PR TITLE
Change cypress timeout for Failed Modal Message to be 2000 instead of…

### DIFF
--- a/cypress/e2e/recModal_spec.cy.js
+++ b/cypress/e2e/recModal_spec.cy.js
@@ -110,8 +110,8 @@ describe('Testing Recommendation Modal', () => {
       cy.wait('@gqlcreateRecommendationMutation')
       cy.get('.failed-container').should('be.visible')
       cy.get('.failed-text').should('be.visible')
-      cy.get('.failed-container', { timeout: 1500 }).should('not.exist')
-      cy.get('.failed-text', { timeout: 1500 }).should('not.exist')
+      cy.get('.failed-container', { timeout: 2000 }).should('not.exist')
+      cy.get('.failed-text', { timeout: 2000 }).should('not.exist')
   })
 
   })


### PR DESCRIPTION
… 1500.

- [x]  Wrote Tests 
- [x] Implemented 
- [ ] Reviewed

## Necessary checkmarks:

- [x] All Tests are Passing in all environments

- [x] The code will run locally

## Type of change

- [ ] New feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Styling
- [ ] Testing
- [ ] This change requires a documentation update


## Description of Change:
This PR changes the cypress timeout from 1500ms to 2000ms for the Failed RecModal Message pop up, so that it can pass the circleci testing.

## Check the correct boxes

- [x]  This broke nothing
- [ ]  This broke some stuff
- [ ]  This broke everything

## Testing Changes

- [ ]  No Tests have been changed
- [x]  Some Tests have been changed
- [ ]  All of the Tests have been changed(Please describe what in the world happened)


## Checklist:

- [x]  My code has no unused/commented out code
- [x]  My code follows the style guidelines of this project
- [x]  My code does not generate new warnings
- [x]  I have reviewed my code
- [ ]  I have commented my code, particularly in hard-to-understand areas (if applicable)


